### PR TITLE
Configure compile workflow to use `include` folder as additional library folder

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -39,5 +39,6 @@ jobs:
             ./examples/wifiTest/wifiTest.ino
             ./examples/readAM2302-Sensor/readAM2302-Sensor.ino
             ./examples/timerInterrupt/timerInterrupt.ino
-          build-property: |
-            build.extra_flags="-I ${{ github.workspace }}/include"
+          cli-compile-flags: |
+            - --library
+            - "${{ github.workspace }}/include"


### PR DESCRIPTION
The "Compile examples foolder" GitHub Actions workflow uses [the "**arduino/compile-sketches**" action](https://github.com/arduino/compile-sketches) to compile this project's Arduino sketches. This action uses Arduino CLI under the hood to perform the compilation.

The `include` folder of the repository contains a header file referenced by an `#include` directive in sketch code. Arduino CLI only discovers libraries under specific default paths, and since that folder is not under one of those paths, this causes compilation of the sketch by the workflow to fail:

https://github.com/hasenradball/ESP32-C3-Examples/actions/runs/11979141944/job/33400679677#step:4:175

```
Compiling sketch: examples/wifiTest
  /home/runner/work/ESP32-C3-Examples/ESP32-C3-Examples/examples/wifiTest/wifiTest.ino:5:10: fatal error: wifi_secrets.h: No such file or directory
      5 | #include "wifi_secrets.h"
        |          ^~~~~~~~~~~~~~~~
  compilation terminated.
```

Arduino CLI can be configured to use libraries from arbitrary paths by specifying those paths via [the `--library` flag of the `arduino-cli compile` command](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_compile/#options). The **arduino/compile-sketches** action supports the injection of arbitrary arguments into the `arduino-cli compile` commands it runs via [the action's `cli-compile-flags` input](https://github.com/arduino/compile-sketches#cli-compile-flags). So by adding the `--library` flag and path to the `include` folder to the action's input, the compilation can be made to find that header in situ.